### PR TITLE
fix: user/ent 조회 시 수정 사항 반영

### DIFF
--- a/src/main/java/chathealth/chathealth/constants/Constants.java
+++ b/src/main/java/chathealth/chathealth/constants/Constants.java
@@ -1,0 +1,17 @@
+package chathealth.chathealth.constants;
+
+import lombok.Getter;
+
+@Getter
+public enum Constants {
+    USER_NOT_FOUND("존재하지 않는 유저입니다."),
+    PASSWORD_NOT_EQUAL("비밀번호가 일치하지 않습니다."),
+    BOARD_NOT_FOUND("존재하지 않는 게시글 입니다.");
+
+    private final String message;
+
+    Constants(String message) {
+        this.message = message;
+    }
+
+}

--- a/src/main/java/chathealth/chathealth/controller/ExceptionController.java
+++ b/src/main/java/chathealth/chathealth/controller/ExceptionController.java
@@ -19,7 +19,7 @@ public class ExceptionController {
     public ErrorResult invalidRequestHandler(MethodArgumentNotValidException e) {
         ErrorResult errorResult = ErrorResult.builder()
                 .message("잘못된 요청입니다.")
-                .code("400")
+                .code(HttpStatus.BAD_REQUEST.toString())
                 .build();
         for (FieldError fieldError : e.getFieldErrors()) {
             errorResult.addValidError(fieldError.getField(), fieldError.getDefaultMessage());

--- a/src/main/java/chathealth/chathealth/dto/request/EntEditDto.java
+++ b/src/main/java/chathealth/chathealth/dto/request/EntEditDto.java
@@ -2,7 +2,6 @@ package chathealth.chathealth.dto.request;
 
 import chathealth.chathealth.entity.member.Address;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -14,16 +13,16 @@ public class EntEditDto {
     @NotBlank(message = "대표자명은 필수입니다.")
     private String ceo;
 
-    @NotBlank(message = "기존 비밀번호를 입력해주세요.")
-    private String pw;
-
-    @NotBlank(message = "새 비밀번호를 입력해주세요.")
-    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,15}$", message = "비밀번호는 영문, 숫자를 포함한 8~20자리여야 합니다.")
-    private String newPw;
-
-    @NotBlank(message = "새 비밀번호를 다시 입력해주세요.")
-    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,15}$", message = "비밀번호는 영문, 숫자를 포함한 8~20자리여야 합니다.")
-    private String newPwCheck;
+//    @NotBlank(message = "기존 비밀번호를 입력해주세요.")
+//    private String pw;
+//
+//    @NotBlank(message = "새 비밀번호를 입력해주세요.")
+//    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,15}$", message = "비밀번호는 영문, 숫자를 포함한 8~20자리여야 합니다.")
+//    private String newPw;
+//
+//    @NotBlank(message = "새 비밀번호를 다시 입력해주세요.")
+//    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,15}$", message = "비밀번호는 영문, 숫자를 포함한 8~20자리여야 합니다.")
+//    private String newPwCheck;
     private Address address;
 
     private String company;

--- a/src/main/java/chathealth/chathealth/dto/request/UserEditDto.java
+++ b/src/main/java/chathealth/chathealth/dto/request/UserEditDto.java
@@ -2,7 +2,6 @@ package chathealth.chathealth.dto.request;
 
 import chathealth.chathealth.entity.member.Address;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -17,15 +16,15 @@ public class UserEditDto {
     @NotBlank(message = "닉네임은 필수입니다.")
     private String nickname;
 
-    @NotBlank(message = "기존 비밀번호를 입력해주세요.")
-    private String pw;
-
-    @NotBlank(message = "새 비밀번호를 입력해주세요.")
-    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,15}$", message = "비밀번호는 영문, 숫자를 포함한 8~20자리여야 합니다.")
-    private String newPw;
-
-    @NotBlank(message = "새 비밀번호를 다시 입력해주세요.")
-    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,15}$", message = "비밀번호는 영문, 숫자를 포함한 8~20자리여야 합니다.")
-    private String newPwCheck;
+//    @NotBlank(message = "기존 비밀번호를 입력해주세요.")
+//    private String pw;
+//
+//    @NotBlank(message = "새 비밀번호를 입력해주세요.")
+//    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,15}$", message = "비밀번호는 영문, 숫자를 포함한 8~20자리여야 합니다.")
+//    private String newPw;
+//
+//    @NotBlank(message = "새 비밀번호를 다시 입력해주세요.")
+//    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,15}$", message = "비밀번호는 영문, 숫자를 포함한 8~20자리여야 합니다.")
+//    private String newPwCheck;
     private Address address;
 }

--- a/src/main/java/chathealth/chathealth/entity/member/Ent.java
+++ b/src/main/java/chathealth/chathealth/entity/member/Ent.java
@@ -1,5 +1,6 @@
 package chathealth.chathealth.entity.member;
 
+import chathealth.chathealth.dto.request.EntEditDto;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import lombok.Getter;
@@ -18,9 +19,9 @@ public class Ent extends Member{
     private String ceo;
     private String entNo;
 
-    public void update(String ceo, String company,Address address, String password) {
-        this.ceo = ceo;
-        this.company = company;
-        super.update(address, password);
+    public void update(EntEditDto entEditDto) {
+        if(entEditDto.getCeo() != null) this.ceo = entEditDto.getCeo();
+        if(entEditDto.getCompany()!=null) this.company = entEditDto.getCompany();
+        super.update(entEditDto.getAddress());
     }
 }

--- a/src/main/java/chathealth/chathealth/entity/member/Member.java
+++ b/src/main/java/chathealth/chathealth/entity/member/Member.java
@@ -47,9 +47,7 @@ public abstract class Member extends BaseEntity {
     @OneToMany(mappedBy = "member")
     private final List<BoardReply> boardReplyList = new ArrayList<>();
 
-    protected void update(Address address, String pw) {
-        this.address = address;
-        this.pw = pw;
+    protected void update(Address address) {
+        if(address != null) this.address = address;
     }
-
 }

--- a/src/main/java/chathealth/chathealth/entity/member/Users.java
+++ b/src/main/java/chathealth/chathealth/entity/member/Users.java
@@ -1,5 +1,6 @@
 package chathealth.chathealth.entity.member;
 
+import chathealth.chathealth.dto.request.UserEditDto;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import lombok.*;
@@ -17,8 +18,8 @@ public class Users extends Member{
     private String nickname;
     private Grade grade;
 
-    public void update(String nickname, Address address, String password) {
-        this.nickname = nickname;
-        super.update(address, password);
+    public void update(UserEditDto userEditDto) {
+        if(userEditDto.getNickname() != null) this.nickname = userEditDto.getNickname();
+        super.update(userEditDto.getAddress());
     }
 }

--- a/src/main/java/chathealth/chathealth/exception/BoardNotFoundException.java
+++ b/src/main/java/chathealth/chathealth/exception/BoardNotFoundException.java
@@ -1,15 +1,16 @@
 package chathealth.chathealth.exception;
 
+import static chathealth.chathealth.constants.Constants.BOARD_NOT_FOUND;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
 public class BoardNotFoundException extends ChatHealthException {
 
-    private static final String MESSAGE = "존재하지 않는 게시글 입니다.";
-
     public BoardNotFoundException() {
-        super(MESSAGE);
+        super(BOARD_NOT_FOUND.getMessage());
     }
 
     @Override
     public int getStatusCode() {
-        return 404;
+        return NOT_FOUND.value();
     }
 }

--- a/src/main/java/chathealth/chathealth/exception/PasswordNotEqual.java
+++ b/src/main/java/chathealth/chathealth/exception/PasswordNotEqual.java
@@ -1,11 +1,12 @@
 package chathealth.chathealth.exception;
 
+import static chathealth.chathealth.constants.Constants.PASSWORD_NOT_EQUAL;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
 public class PasswordNotEqual extends ChatHealthException {
 
-    private static final String MESSAGE = "비밀번호가 일치하지 않습니다.";
-
     public PasswordNotEqual() {
-        super(MESSAGE);
+        super(PASSWORD_NOT_EQUAL.getMessage());
     }
 
     public PasswordNotEqual(String message) {
@@ -14,6 +15,6 @@ public class PasswordNotEqual extends ChatHealthException {
 
     @Override
     public int getStatusCode() {
-        return 400;
+        return BAD_REQUEST.value();
     }
 }

--- a/src/main/java/chathealth/chathealth/exception/UserNotFound.java
+++ b/src/main/java/chathealth/chathealth/exception/UserNotFound.java
@@ -1,15 +1,17 @@
 package chathealth.chathealth.exception;
 
+import chathealth.chathealth.constants.Constants;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
 public class UserNotFound extends ChatHealthException {
 
-    private static final String MESSAGE = "존재하지 않는 유저입니다.";
-
     public UserNotFound() {
-        super(MESSAGE);
+        super(Constants.USER_NOT_FOUND.getMessage());
     }
 
     @Override
     public int getStatusCode() {
-        return 404;
+        return NOT_FOUND.value();
     }
 }

--- a/src/test/java/chathealth/chathealth/controller/MemberControllerTest.java
+++ b/src/test/java/chathealth/chathealth/controller/MemberControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 
+import static chathealth.chathealth.entity.member.Role.*;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -55,6 +56,7 @@ class MemberControllerTest {
                 .email("jjang051.hanmail.net")
                 .pw("1234")
                 .grade(Grade.valueOf("BRONZE"))
+                .role(USER)
                 .profile("profile0321984u32895")
                 .build();
 
@@ -79,7 +81,7 @@ class MemberControllerTest {
                 .address(new Address("서울시 강남구", "123-123", 12345))
                 .birth(LocalDate.of(1995, 3, 21))
                 .profile("profile0321984u32895")
-                .role(Role.valueOf("WAITING_ENT"))
+                .role(valueOf("WAITING_ENT"))
                 .ceo("장공오일")
                 .entNo("1234-1234-1234")
                 .company("중앙HTA")
@@ -140,6 +142,7 @@ class MemberControllerTest {
                 .pw("1234")
                 .address(address)
                 .grade(Grade.valueOf("BRONZE"))
+                .role(USER)
                 .profile("profile0321984u32895")
                 .build();
 
@@ -151,9 +154,6 @@ class MemberControllerTest {
                 .id(user.getId())
                 .nickname("조원우짱")
                 .address(newAddress)
-                .pw("1234")
-                .newPw("jjang0512@")
-                .newPwCheck("jjang0512@")
                 .build();
 
         //expected
@@ -161,114 +161,6 @@ class MemberControllerTest {
                         .contentType(APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(userEditDto)))
                 .andExpect(status().isOk())
-                .andDo(print());
-    }
-    @Test
-    @DisplayName("유저 정보 수정 실패 - 기존 비밀번호 불일치")
-    public void test6() throws Exception {
-//        given
-        Address address = new Address("서울시 강남구", "123-123", 12345);
-//
-        Users user = Users.builder()
-                .name("장성호")
-                .nickname("짱공오일")
-                .email("jjang051.hanmail.net")
-                .pw("1234")
-                .address(address)
-                .grade(Grade.valueOf("BRONZE"))
-                .profile("profile0321984u32895")
-                .build();
-
-        memberRepository.save(user);
-
-        Address newAddress = new Address("대전시 유성구 가마로00길 11", "22-33", 98776);
-
-        UserEditDto userEditDto = UserEditDto.builder()
-                .id(user.getId())
-                .nickname("조원우짱")
-                .address(newAddress)
-                .pw("12345")
-                .newPw("jjang0512@")
-                .newPwCheck("jjang0512@")
-                .build();
-
-        //expected
-        mockMvc.perform(patch("/member/user/{id}", user.getId())
-                        .contentType(APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(userEditDto)))
-                .andExpect(status().isBadRequest())
-                .andDo(print());
-    }
-    @Test
-    @DisplayName("유저 정보 수정 실패 - 새 비밀번호 불일치")
-    public void test7() throws Exception {
-//        given
-        Address address = new Address("서울시 강남구", "123-123", 12345);
-//
-        Users user = Users.builder()
-                .name("장성호")
-                .nickname("짱공오일")
-                .email("jjang051.hanmail.net")
-                .pw("1234")
-                .address(address)
-                .grade(Grade.valueOf("BRONZE"))
-                .profile("profile0321984u32895")
-                .build();
-
-        memberRepository.save(user);
-
-        Address newAddress = new Address("대전시 유성구 가마로00길 11", "22-33", 98776);
-
-        UserEditDto userEditDto = UserEditDto.builder()
-                .id(user.getId())
-                .nickname("조원우짱")
-                .address(newAddress)
-                .pw("12345")
-                .newPw("jjang0512@")
-                .newPwCheck("jjang0512@1")
-                .build();
-
-        //expected
-        mockMvc.perform(patch("/member/user/{id}", user.getId())
-                        .contentType(APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(userEditDto)))
-                .andExpect(status().isBadRequest())
-                .andDo(print());
-    }
-    @Test
-    @DisplayName("유저 정보 수정 실패 - 비밀번호 형식 불일치")
-    public void test8() throws Exception {
-//        given
-        Address address = new Address("서울시 강남구", "123-123", 12345);
-//
-        Users user = Users.builder()
-                .name("장성호")
-                .nickname("짱공오일")
-                .email("jjang051.hanmail.net")
-                .pw("1234")
-                .grade(Grade.valueOf("BRONZE"))
-                .address(address)
-                .profile("profile0321984u32895")
-                .build();
-
-        memberRepository.save(user);
-
-        Address newAddress = new Address("대전시 유성구 가마로00길 11", "22-33", 98776);
-
-        UserEditDto userEditDto = UserEditDto.builder()
-                .id(user.getId())
-                .nickname("조원우짱")
-                .address(newAddress)
-                .pw("12345")
-                .newPw("jjang0512")
-                .newPwCheck("jjang0512")
-                .build();
-
-        //expected
-        mockMvc.perform(patch("/member/user/{id}", user.getId())
-                        .contentType(APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(userEditDto)))
-                .andExpect(status().isBadRequest())
                 .andDo(print());
     }
 
@@ -285,7 +177,7 @@ class MemberControllerTest {
                 .pw("1234")
                 .address(address)
                 .profile("profile0321984u32895")
-                .role(Role.valueOf("WAITING_ENT"))
+                .role(valueOf("WAITING_ENT"))
                 .entNo("1234-1234-1234")
                 .build();
 
@@ -298,9 +190,6 @@ class MemberControllerTest {
                 .ceo("조원우")
                 .address(newAddress)
                 .company("조원우컴퍼니")
-                .pw("1234")
-                .newPw("jjang0512@")
-                .newPwCheck("jjang0512@")
                 .build();
 
         //expected

--- a/src/test/java/chathealth/chathealth/service/MemberServiceTest.java
+++ b/src/test/java/chathealth/chathealth/service/MemberServiceTest.java
@@ -4,8 +4,10 @@ import chathealth.chathealth.dto.request.EntEditDto;
 import chathealth.chathealth.dto.request.UserEditDto;
 import chathealth.chathealth.dto.response.EntInfoDto;
 import chathealth.chathealth.dto.response.UserInfoDto;
-import chathealth.chathealth.entity.member.*;
-import chathealth.chathealth.exception.PasswordNotEqual;
+import chathealth.chathealth.entity.member.Address;
+import chathealth.chathealth.entity.member.Ent;
+import chathealth.chathealth.entity.member.Grade;
+import chathealth.chathealth.entity.member.Users;
 import chathealth.chathealth.exception.UserNotFound;
 import chathealth.chathealth.repository.MemberRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -16,8 +18,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static chathealth.chathealth.entity.member.Role.USER;
+import static chathealth.chathealth.entity.member.Role.valueOf;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 @Transactional
@@ -42,6 +46,7 @@ class MemberServiceTest {
                 .pw("1234")
                 .grade(Grade.valueOf("BRONZE"))
                 .profile("profile0321984u32895")
+                .role(USER)
                 .address(address)
                 .build();
 
@@ -89,7 +94,7 @@ class MemberServiceTest {
                 .address(new Address("서울시 강남구", "123-123", 12345))
                 .birth(LocalDate.of(1995, 3, 21))
                 .profile("profile0321984u32895")
-                .role(Role.valueOf("WAITING_ENT"))
+                .role(valueOf("WAITING_ENT"))
                 .ceo("장공오일")
                 .entNo("1234-1234-1234")
                 .company("중앙HTA")
@@ -107,7 +112,7 @@ class MemberServiceTest {
         assertThat(entInfo.getAddress().getPostcode()).isEqualTo(12345);
         assertThat(entInfo.getBirth()).isEqualTo(LocalDate.of(1995, 3, 21));
         assertThat(entInfo.getProfile()).isEqualTo("profile0321984u32895");
-        assertThat(entInfo.getRole()).isEqualTo(Role.valueOf("WAITING_ENT"));
+        assertThat(entInfo.getRole()).isEqualTo(valueOf("WAITING_ENT"));
         assertThat(entInfo.getCeo()).isEqualTo("장공오일");
         assertThat(entInfo.getEntNo()).isEqualTo("1234-1234-1234");
         assertThat(entInfo.getCompany()).isEqualTo("중앙HTA");
@@ -122,7 +127,7 @@ class MemberServiceTest {
                 .address(new Address("서울시 강남구", "123-123", 12345))
                 .birth(LocalDate.of(1995, 3, 21))
                 .profile("profile0321984u32895")
-                .role(Role.valueOf("WAITING_ENT"))
+                .role(valueOf("WAITING_ENT"))
                 .ceo("장공오일")
                 .entNo("1234-1234-1234")
                 .company("중앙HTA")
@@ -147,6 +152,7 @@ class MemberServiceTest {
                 .grade(Grade.valueOf("BRONZE"))
                 .profile("profile0321984u32895")
                 .address(address)
+                .role(USER)
                 .build();
 
         memberRepository.save(user);
@@ -154,9 +160,6 @@ class MemberServiceTest {
         UserEditDto updateUser = UserEditDto.builder()
                 .nickname("공짱오일")
                 .address(new Address("대전시 유성구 가마로00길 11", "22-33", 98776))
-                .pw("1234")
-                .newPw("jjang0512")
-                .newPwCheck("jjang0512")
                 .build();
 
         memberService.updateUserInfo(user.getId(), updateUser);
@@ -175,70 +178,8 @@ class MemberServiceTest {
         assertThat(userInfo.getAddress().getAddress()).isEqualTo("대전시 유성구 가마로00길 11");
         assertThat(userInfo.getAddress().getAddressDetail()).isEqualTo("22-33");
         assertThat(userInfo.getAddress().getPostcode()).isEqualTo(98776);
-        assertThat(userInfo.getPw()).isEqualTo("jjang0512");
     }
-    @Test
-    @DisplayName("유저 정보 수정 실패 - 새로운 비밀번호 불일치")
-    public void test6() throws Exception{
-        //given
-        Address address = new Address("서울시 강남구", "123-123", 12345);
 
-        Users user = Users.builder()
-                .name("장성호")
-                .nickname("짱공오일")
-                .email("jjang051.hanmail.net")
-                .pw("1234")
-                .grade(Grade.valueOf("BRONZE"))
-                .profile("profile0321984u32895")
-                .address(address)
-                .build();
-
-        memberRepository.save(user);
-        //when
-        UserEditDto updateUser = UserEditDto.builder()
-                .nickname("")
-                .address(new Address("대전시 유성구 가마로00길 11", "22-33", 98776))
-                .pw("1234")
-                .newPw("jjang0512")
-                .newPwCheck("jjang05132")
-                .build();
-
-        //then
-        assertThatThrownBy(() -> memberService.updateUserInfo(user.getId(), updateUser))
-                .isInstanceOf(PasswordNotEqual.class)
-                .hasMessageContaining("새로운 비밀번호가 일치하지 않습니다.");
-    }
-    @Test
-    @DisplayName("유저 정보 수정 실패 - 기존 비밀번호 불일치")
-    public void test7() throws Exception{
-        //given
-        Address address = new Address("서울시 강남구", "123-123", 12345);
-
-        Users user = Users.builder()
-                .name("장성호")
-                .nickname("짱공오일")
-                .email("jjang051.hanmail.net")
-                .pw("1234")
-                .grade(Grade.valueOf("BRONZE"))
-                .profile("profile0321984u32895")
-                .address(address)
-                .build();
-
-        memberRepository.save(user);
-        //when
-        UserEditDto updateUser = UserEditDto.builder()
-                .nickname("")
-                .address(new Address("대전시 유성구 가마로00길 11", "22-33", 98776))
-                .pw("12345")
-                .newPw("jjang0512")
-                .newPwCheck("jjang0512")
-                .build();
-
-        //then
-        assertThatThrownBy(() -> memberService.updateUserInfo(user.getId(), updateUser))
-                .isInstanceOf(PasswordNotEqual.class)
-                .hasMessageContaining("비밀번호가 일치하지 않습니다.");
-    }
 
     @Test
     @DisplayName("사업자 정보 수정")
@@ -249,7 +190,7 @@ class MemberServiceTest {
                 .address(new Address("서울시 강남구", "123-123", 12345))
                 .birth(LocalDate.of(1995, 3, 21))
                 .profile("profile0321984u32895")
-                .role(Role.valueOf("WAITING_ENT"))
+                .role(valueOf("WAITING_ENT"))
                 .ceo("장공오일")
                 .pw("1234")
                 .entNo("1234-1234-1234")
@@ -264,9 +205,6 @@ class MemberServiceTest {
                 .ceo("장공오일")
                 .company("중앙HTA")
                 .address(newAddress)
-                .pw("1234")
-                .newPw("jjang0512@")
-                .newPwCheck("jjang0512@")
                 .build();
         //when
         memberService.updateEntInfo(ent.getId(), updateEnt);


### PR DESCRIPTION
1. memberId가 서로 다르면 예외가 발생하도록 함
2. getMember 메서드 분리한거 다시 복구 
3. status 코드 상수 처리
4. MESSAGE enum 클래스 상수 처 & 삼항 연산자 -> DTO에서 null 처리
6. 회원정보 수정 시 비밀번호는 따로 처리하기 위해 제거