### PR TITLE
fix: yml default batchsize 설정을 통해 fetchjoin 하지 않고 onetomany 관계에 있는 엔티…

### DIFF
--- a/src/main/java/chathealth/chathealth/dto/response/PostResponse.java
+++ b/src/main/java/chathealth/chathealth/dto/response/PostResponse.java
@@ -5,13 +5,14 @@ import chathealth.chathealth.entity.post.PicturePost;
 import chathealth.chathealth.entity.post.SymptomType;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 
 import java.util.List;
 
 @Getter
-@Builder
 @ToString
+@Setter
 public class PostResponse {
 
     private Long id;
@@ -26,16 +27,29 @@ public class PostResponse {
     private SymptomType symptom;
     private List<Material> material;
 
-    // yyyy-MM-dd HH:mm:ss 변환
-    private String createdDate;
-
     // yyyy-MM-dd 변환
     private String createdAt;
 
     private Long count;
 
-    private Long hitCount;
-    private Long likeCount;
-    private Long reviewCount;
+    private Integer hitCount;
+    private Integer likeCount;
+    private Integer reviewCount;
 
+    @Builder
+    public PostResponse(Long id, String title, String content, List<PicturePost> picturePost, String representativeImg, String company, SymptomType symptom, List<Material> material, String createdAt, Long count, Integer hitCount, Integer likeCount, Integer reviewCount) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+        this.picturePost = picturePost;
+        this.representativeImg = representativeImg;
+        this.company = company;
+        this.symptom = symptom;
+        this.material = material;
+        this.createdAt = createdAt;
+        this.count = count;
+        this.hitCount = hitCount;
+        this.likeCount = likeCount;
+        this.reviewCount = reviewCount;
+    }
 }

--- a/src/main/java/chathealth/chathealth/entity/post/Post.java
+++ b/src/main/java/chathealth/chathealth/entity/post/Post.java
@@ -68,18 +68,18 @@ public class Post extends BaseEntity {
     private List<Review> reviewList = new ArrayList<>();
 
 
-    public Long getPostHitCount() {
-        if (postHitList == null) return 0L;
-        return (long) postHitList.size();
+    public Integer getPostHitCount() {
+        if (postHitList == null) return 0;
+        return postHitList.size();
     }
 
-    public Long getPostLikeCount() {
-        if(postLikeList == null) return 0L;
-        return (long) postLikeList.size();
+    public Integer getPostLikeCount() {
+        if(postLikeList == null) return 0;
+        return postLikeList.size();
     }
 
-    public Long getReviewCount() {
-        if(reviewList == null) return 0L;
-        return (long) reviewList.size();
+    public Integer getReviewCount() {
+        if(reviewList == null) return 0;
+        return reviewList.size();
     }
 }

--- a/src/main/java/chathealth/chathealth/repository/post/PostRepositoryImpl.java
+++ b/src/main/java/chathealth/chathealth/repository/post/PostRepositoryImpl.java
@@ -12,13 +12,9 @@ import lombok.RequiredArgsConstructor;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static chathealth.chathealth.entity.QReview.review;
-import static chathealth.chathealth.entity.member.QEnt.ent;
 import static chathealth.chathealth.entity.post.QMaterial.material;
-import static chathealth.chathealth.entity.post.QMaterialPost.materialPost;
 import static chathealth.chathealth.entity.post.QPost.post;
 import static chathealth.chathealth.entity.post.QPostHit.postHit;
-import static chathealth.chathealth.entity.post.QPostLike.postLike;
 import static chathealth.chathealth.entity.post.QSymptom.symptom;
 
 @RequiredArgsConstructor
@@ -35,19 +31,17 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                         companyContains(postSearch.getCompany()),
                         symptomTypeEq(postSearch.getSymptomType()),
                         materialIn(postSearch.getMaterialName())
-                        )
-                .innerJoin(post.member, ent)
+                )
+                .innerJoin(post.member)
                 .fetchJoin()
-                .leftJoin(post.symptom, symptom)
+                .leftJoin(post.symptom)
                 .fetchJoin()
-                .rightJoin(materialPost).on(materialPost.post.eq(post))
+                .leftJoin(post.materialList)
                 .fetchJoin()
-                .leftJoin(materialPost).on(materialPost.material.eq(material))
-                .fetchJoin()
-                .leftJoin(postHit).on(postHit.post.eq(post))
-                .leftJoin(postLike).on(postLike.post.eq(post))
-                .leftJoin(review).on(review.post.eq(post))
-                .groupBy(post)
+                .leftJoin(post.postHitList)
+                .leftJoin(post.postLikeList)
+                .leftJoin(post.reviewList)
+                .leftJoin(post.postImgList)
                 .orderBy(getOrderSpecifier(postSearch))
                 .limit(postSearch.getSize())
                 .offset(postSearch.getOffset())
@@ -65,8 +59,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                         materialIn(postSearch.getMaterialName())
                 )
                 .leftJoin(post.symptom, symptom)
-                .rightJoin(materialPost).on(materialPost.post.eq(post))
-                .leftJoin(materialPost).on(materialPost.material.eq(material))
+                .leftJoin(post.materialList)
                 .fetchOne();
     }
 
@@ -130,7 +123,9 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
         if(company == null || company.isEmpty()){
             return null;
         }
-        return ent.company.contains(company);
+        System.out.println("ent.company = " + post.member.company);
+        return post.member.company.contains(company);
+//        return ent.company.contains(company);
     }
 
     private static OrderSpecifier<?> getOrderSpecifier(PostSearch postSearch) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,8 +7,7 @@ server:
 spring:
   profiles:
     include: oauth
-    active: dev # application-prod
-
+    active: prod # application-prod
   output:
     ansi:
       enabled: always
@@ -22,6 +21,7 @@ spring:
       hibernate:
         format_sql: true
         use_sql_comments: true # false
+        default_batch_fetch_size: 100
 
   ## high quality img  ##
   servlet:
@@ -50,4 +50,4 @@ file:
   path: C:/upload/
 
 pagination:
-  size: 10
+  size: 20

--- a/src/main/resources/templates/post/post.html
+++ b/src/main/resources/templates/post/post.html
@@ -463,7 +463,7 @@
 
                         html += '<div class="col-lg-3 col-sm-6 mb-4">';
                         html += '    <div class="card h-100 shadow-sm bg-light"> <!-- Original background color -->';
-                        html += '        <a href="' + item.link + '" style="text-decoration: none; color: inherit;">';
+                        html += '        <a href="' + item.id + '" style="text-decoration: none; color: inherit;">';
                         html += '            <img src="' + item.representativeImg + '" class="card-img-top rounded" alt="Image of ' + item.title + '" onError="this.onerror=null; this.src=\'/img/basic_post.svg\'">';
                         html += '            <h5 class="card-title font-weight-bold text-center" style="margin-top: 10px;">' + item.title + '</h5>';
                         html += '        </a>';

--- a/src/test/java/chathealth/chathealth/repository/post/PostRepositoryImplTest.java
+++ b/src/test/java/chathealth/chathealth/repository/post/PostRepositoryImplTest.java
@@ -45,7 +45,7 @@ class PostRepositoryImplTest {
         //given
         PostSearch postSearch = PostSearch.builder()
                 .title("제목입니다")
-                .company("회사입니다")
+//                .company("회사입니다")
                 .symptomType(INTESTINE)
                 .materialName(List.of("아스피린", "타이레놀"))
                 .build();

--- a/src/test/java/chathealth/chathealth/service/PostServiceTest.java
+++ b/src/test/java/chathealth/chathealth/service/PostServiceTest.java
@@ -8,6 +8,7 @@ import chathealth.chathealth.entity.member.Users;
 import chathealth.chathealth.entity.post.*;
 import chathealth.chathealth.repository.*;
 import chathealth.chathealth.repository.post.PostRepository;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,6 +44,8 @@ class PostServiceTest {
     PostHitRepository postHitRepository;
     @Autowired
     PostRestController postHitService;
+    @Autowired
+    EntityManager em;
 
     @Test
     @DisplayName("포스트 목록 조회")
@@ -53,7 +56,7 @@ class PostServiceTest {
                 .title("입니다")
                 .company("중앙컴퍼니")
                 .symptomType(INTESTINE)
-                .materialName(List.of("아스피린", "타이레놀"))
+                .materialName(List.of("프로바이오틱스"))
                 .ordercondition(RECENT)
                 .size(20)
                 .build();
@@ -61,41 +64,41 @@ class PostServiceTest {
         Ent ent = Ent.builder()
                 .company("중앙컴퍼니")
                 .build();
-        memberRepository.save(ent);
+        Ent savedEnt = memberRepository.save(ent);
 
         Symptom symptom = Symptom.builder()
                 .symptomName(INTESTINE)
                 .build();
-        symptomRepository.save(symptom);
+        Symptom savedSymptom = symptomRepository.save(symptom);
 
         Material material = Material.builder()
-                .materialName("아스피린")
+                .materialName("프로바이오틱스")
                 .build();
-        materialRepository.save(material);
+        Material savedMaterial = materialRepository.save(material);
 
         Post post = Post.builder()
                 .title("제목입니다")
-                .symptom(symptom)
-                .member(ent)
+                .symptom(savedSymptom)
+                .member(savedEnt)
                 .build();
-        postRepository.save(post);
+        Post savedPost = postRepository.save(post);
 
         MaterialPost materialPost = MaterialPost.builder()
-                .material(material)
-                .post(post)
+                .material(savedMaterial)
+                .post(savedPost)
                 .build();
 
         materialPostRepository.save(materialPost);
 
         PicturePost picture1 = picturePostRepository.save(PicturePost.builder()
                 .pictureUrl("이미지유알엘1")
-                .post(post)
+                .post(savedPost)
                 .orders(0)
                 .build());
 
         PicturePost picture2 = picturePostRepository.save(PicturePost.builder()
                 .pictureUrl("이미지 유알엘2")
-                .post(post)
+                .post(savedPost)
                 .orders(1)
                 .build());
 
@@ -109,27 +112,27 @@ class PostServiceTest {
 
             Post post1 = Post.builder()
                     .title("제목입니다")
-                    .symptom(symptom)
-                    .member(ent)
+                    .symptom(savedSymptom)
+                    .member(savedEnt)
                     .build();
-            postRepository.save(post1);
+            Post savedPost1 = postRepository.save(post1);
 
             MaterialPost materialPost1 = MaterialPost.builder()
-                    .material(material)
-                    .post(post1)
+                    .material(savedMaterial)
+                    .post(savedPost1)
                     .build();
 
-            materialPostRepository.save(materialPost1);
+            MaterialPost savedMaterial1 = materialPostRepository.save(materialPost1);
 
             PicturePost picture4 = picturePostRepository.save(PicturePost.builder()
-                    .pictureUrl("이미지유알엘3")
-                    .post(post1)
+                    .pictureUrl("이미지3")
+                    .post(savedPost1)
                     .orders(0)
                     .build());
 
             PicturePost picture3 = picturePostRepository.save(PicturePost.builder()
                     .pictureUrl("이미지 유알엘2")
-                    .post(post1)
+                    .post(savedPost1)
                     .orders(1)
                     .build());
             List<PicturePost> pictures1 = new ArrayList<>();
@@ -138,19 +141,24 @@ class PostServiceTest {
             picturePostRepository.saveAll(pictures1);
 
             postHitRepository.save(PostHit.builder()
-                    .post(post1)
+                    .post(savedPost1)
                     .build());
             postHitRepository.save(PostHit.builder()
-                    .post(post1)
+                    .post(savedPost1)
                     .build());
         }
+        em.flush();
+        em.clear();
 
         //when
         List<PostResponse> posts = postService.getPosts(postSearch);
+        for (PostResponse postResponse : posts) {
+            System.out.println("postResponsezzz = " + postResponse);
+        }
 
         //then
         assertThat(posts.size()).isEqualTo(20);
-        assertThat(posts.get(0).getRepresentativeImg()).isEqualTo("이미지유알엘3");
+        assertThat(posts.get(0).getRepresentativeImg()).isEqualTo("이미지3");
 //        assertThat(posts.get(0).getCount()).isEqualTo(90);
 
     }


### PR DESCRIPTION
yml default batchsize 설정을 통해 fetchjoin 하지 않고 onetomany 관계에 있는 엔티티 조회 
-> 오라클에서도 ok. 
representativeImg 따로 조회해서 n+1 현상 완화하기 위해 한 번에 조회해서 orders가 0인 것만 필터링