### PR TITLE
fix: 입장, 퇴장 메세지 나오지 않던거 다시 나오게 함

### DIFF
--- a/src/main/java/chathealth/chathealth/controller/ChatMessageController.java
+++ b/src/main/java/chathealth/chathealth/controller/ChatMessageController.java
@@ -1,6 +1,7 @@
 package chathealth.chathealth.controller;
 
 import chathealth.chathealth.dto.request.ChatMessageDto;
+import chathealth.chathealth.dto.request.ChatMessageType;
 import chathealth.chathealth.dto.request.CreateChatRoom;
 import chathealth.chathealth.dto.response.ChatMessageResponse;
 import chathealth.chathealth.dto.response.member.CustomUserDetails;
@@ -32,11 +33,15 @@ public class ChatMessageController {
 
     @MessageMapping("/chat/message")
     public void message(ChatMessageDto messageDto, Principal principal) {
-        System.out.println("messageDto = " + messageDto);
+
+        if(messageDto.getType() == ChatMessageType.ENTER) {
+            messageDto.setContent(ChatMessageType.ENTER.getMessage());
+        } else if(messageDto.getType() == ChatMessageType.QUIT) {
+            messageDto.setContent(ChatMessageType.QUIT.getMessage());
+        }
+
         Errors errors = new BeanPropertyBindingResult(messageDto, "messageDto");
-        System.out.println("errors = " + errors);
         validator.validate(messageDto, errors);
-        System.out.println("validator = " + validator);
 
         if (errors.hasErrors()) {
             log.error("validation error : {}", errors);

--- a/src/main/java/chathealth/chathealth/controller/ChatRoomController.java
+++ b/src/main/java/chathealth/chathealth/controller/ChatRoomController.java
@@ -12,7 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -47,7 +46,7 @@ public class ChatRoomController {
     }
 
     //채팅방 기존 메세지(slice)
-    @PreAuthorize("permitAll()")
+//    @PreAuthorize("permitAll()")
     @ResponseBody
     @GetMapping("/chat/room/{id}")
     public Slice<ChatMessageResponse> getChatMessages(@PathVariable Long id, Pageable pageable,

--- a/src/main/java/chathealth/chathealth/dto/request/ChatMessageType.java
+++ b/src/main/java/chathealth/chathealth/dto/request/ChatMessageType.java
@@ -1,13 +1,16 @@
 package chathealth.chathealth.dto.request;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
+@Getter
 public enum ChatMessageType {
 
-    ENTER("입장"),
-    TALK("일반 채팅"),
-    QUIT("퇴장");
+    ENTER("입장", "님이 입장하셨습니다."),
+    TALK("일반 채팅", ""),
+    QUIT("퇴장", "님이 퇴장하셨습니다.");
 
     private final String description;
+    private final String message;
 }

--- a/src/main/java/chathealth/chathealth/dto/response/ChatMessageResponse.java
+++ b/src/main/java/chathealth/chathealth/dto/response/ChatMessageResponse.java
@@ -1,5 +1,6 @@
 package chathealth.chathealth.dto.response;
 
+import chathealth.chathealth.dto.request.ChatMessageType;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -18,12 +19,15 @@ public class ChatMessageResponse {
 
     private boolean isMine;
 
+    private ChatMessageType type;
+
     @Builder
-    public ChatMessageResponse(String nickname, String message, LocalDateTime timestamp,Long senderId, boolean isMine) {
+    public ChatMessageResponse(String nickname, String message, LocalDateTime timestamp,Long senderId, boolean isMine, ChatMessageType type) {
         this.nickname = nickname;
         this.message = message;
         this.timestamp = timestamp;
         this.senderId = senderId;
         this.isMine = isMine;
+        this.type = type;
     }
 }

--- a/src/main/java/chathealth/chathealth/repository/charRoom/ChatRoomRepositoryImpl.java
+++ b/src/main/java/chathealth/chathealth/repository/charRoom/ChatRoomRepositoryImpl.java
@@ -5,6 +5,7 @@ import chathealth.chathealth.entity.chatRoom.ChatRoom;
 import chathealth.chathealth.entity.chatRoom.QChatRoom;
 import chathealth.chathealth.entity.member.Member;
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -27,7 +28,13 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom{
         BooleanBuilder whereClause = new BooleanBuilder(chatRoomMember.deletedDate.isNull());
 
         if (condition == ChatSearchCondition.JOINED) {
-            whereClause.and(chatRoomMember.member.eq(member));
+            whereClause.and(chatRoom.in(
+                    JPAExpressions.select(chatRoomMember.chatRoom)
+                            .from(chatRoomMember)
+                            .where(chatRoomMember.member.eq(member)
+                                    .and(chatRoomMember.deletedDate.isNull())))
+            );
+
         }
 
         List<ChatRoom> chatRooms = queryFactory.selectFrom(chatRoom)

--- a/src/main/java/chathealth/chathealth/repository/message/MessageRepositoryImpl.java
+++ b/src/main/java/chathealth/chathealth/repository/message/MessageRepositoryImpl.java
@@ -95,8 +95,6 @@ public class MessageRepositoryImpl implements MessageRepositoryCustom {
                     return MessageReceiveResponse.get(message, sender);
                 }).toList();
 
-        System.out.println("list.size() = " + list.size());
-
         return new PageImpl<>(list, pageable, count == null ? 0 : count);
     }
 }

--- a/src/main/java/chathealth/chathealth/repository/post/PostRepositoryImpl.java
+++ b/src/main/java/chathealth/chathealth/repository/post/PostRepositoryImpl.java
@@ -123,9 +123,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
         if(company == null || company.isEmpty()){
             return null;
         }
-        System.out.println("ent.company = " + post.member.company);
         return post.member.company.contains(company);
-//        return ent.company.contains(company);
     }
 
     private static OrderSpecifier<?> getOrderSpecifier(PostSearch postSearch) {

--- a/src/main/java/chathealth/chathealth/service/BoardService.java
+++ b/src/main/java/chathealth/chathealth/service/BoardService.java
@@ -139,7 +139,6 @@ public class BoardService {
             }
         }
 
-        System.out.println("board.getCreatedDate() = " + board.getCreatedDate());
 
         Users user = board.getUser();
         return BoardResponse.builder()

--- a/src/main/java/chathealth/chathealth/service/ChatService.java
+++ b/src/main/java/chathealth/chathealth/service/ChatService.java
@@ -2,7 +2,6 @@ package chathealth.chathealth.service;
 
 import chathealth.chathealth.constants.ChatSearchCondition;
 import chathealth.chathealth.dto.request.ChatMessageDto;
-import chathealth.chathealth.dto.request.ChatMessageType;
 import chathealth.chathealth.dto.request.CreateChatRoom;
 import chathealth.chathealth.dto.response.ChatMessageResponse;
 import chathealth.chathealth.dto.response.ChatRoomInner;
@@ -27,9 +26,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.security.Principal;
 import java.util.List;
-
-import static chathealth.chathealth.constants.Constants.ENTER_MESSAGE;
-import static chathealth.chathealth.constants.Constants.QUIT_MESSAGE;
 
 @Service
 @RequiredArgsConstructor
@@ -82,6 +78,7 @@ public class ChatService {
                             .nickname(chatMessage.getSender().getChatNickname())
                             .timestamp(chatMessage.getTimestamp())
                             .isMine(isMine)
+                            .type(chatMessage.getType())
                             .build();})
                 .toList();
 
@@ -93,12 +90,6 @@ public class ChatService {
         ChatRoom chatRoom = chatRoomRepository.findById(messageDto.getRoomId()).orElseThrow(RoomNotFound::new);
         Member member = memberRepository.findByEmail(senderEmail).orElseThrow(UserNotFound::new);
         ChatRoomMember chatRoomMember = chatRoomMemberRepository.findByChatRoomAndMemberAndDeletedDateIsNull(chatRoom, member).orElseThrow(UserNotFound::new);
-
-        if (messageDto.getType().equals(ChatMessageType.ENTER)) {
-            messageDto.setContent(messageDto.getNickname() + ENTER_MESSAGE.getMessage());
-        } else if (messageDto.getType().equals(ChatMessageType.QUIT)) {
-            messageDto.setContent(chatRoomMember.getChatNickname() + QUIT_MESSAGE.getMessage());
-        }
 
         ChatMessage message = ChatMessage.builder()
                 .chatRoom(chatRoom)
@@ -115,6 +106,7 @@ public class ChatService {
                 .nickname(message.getSender().getChatNickname())
                 .timestamp(message.getTimestamp())
                 .senderId(messageDto.getSenderId())
+                .type(messageDto.getType())
                 .build();
 
     }

--- a/src/main/java/chathealth/chathealth/service/MessageService.java
+++ b/src/main/java/chathealth/chathealth/service/MessageService.java
@@ -100,7 +100,6 @@ public class MessageService {
         Message message = messageRepository.findFetchById(messageId).orElseThrow(MessageNotFound::new);
 
         if (message.getIsRead() == 0) {
-            System.out.println("읽지 않은 쪽지 읽음 처리");
             message.readMessage();
         }
 

--- a/src/main/resources/static/css/layout.css
+++ b/src/main/resources/static/css/layout.css
@@ -509,3 +509,29 @@ footer {
     height: 200px; /* 원하는 높이로 설정 */
     object-fit: cover; /* 이미지를 비율을 유지하면서 크롭 */
 }
+
+.enter-message{
+    color: #7863d7;
+    font-size: 20px;
+    font-weight: bold;
+    text-align: center;
+}
+
+.quit-message{
+    color: #d03c3c;
+    font-size: 20px;
+    font-weight: bold;
+    text-align: center;
+}
+
+.timestamp-enter{
+    color: #be8181;
+    text-align: center;
+    font-size: 12px;
+}
+
+.timestamp-quit{
+    color: #be8181;
+    text-align: center;
+    font-size: 12px;
+}

--- a/src/main/resources/templates/board/board.html
+++ b/src/main/resources/templates/board/board.html
@@ -60,7 +60,6 @@
 
                         <div class="context-menu">
                             <a href="#" class="send-message-link" th:data-member-id="${board.memberId}" th:data-member-name="${board.nickname != null ? board.nickname : board.name}">쪽지 보내기</a>
-                            <a th:href="@{/member/user/{id}(id=${board.memberId})}">유저 정보 보기</a>
                         </div>
 
 
@@ -278,7 +277,6 @@
                         html += "</span>";
                         html += "<div class='context-menu'>";
                         html += "<a href='#' class='send-message-link' data-member-id='" + item.memberId + "' data-member-name='" + item.memberNickname + "'>쪽지 보내기</a>";
-                        html += "<a href='/member/user/" + item.memberId + "'>유저 정보 보기</a>";
                         html += "</div>";
                         html += "<span><i class='fa " + iconClass + " " + textColor + "'></i></span>";
                         if (item.memberId === memberId) {

--- a/src/main/resources/templates/board/boards.html
+++ b/src/main/resources/templates/board/boards.html
@@ -111,7 +111,6 @@
                                   th:text="${item.nickname != null ? item.nickname : item.name}">사용자 이름</span>
                             <div class="context-menu">
                                 <a href="#" class="send-message-link" th:data-member-id="${item.memberId}" th:data-member-name="${item.nickname != null ? item.nickname : item.name}">쪽지 보내기</a>
-                                <a th:href="@{/member/user/{id}(id=${item.memberId})}">유저 정보 보기</a>
                             </div>
                         </div>
                     </td>
@@ -188,12 +187,13 @@
 
                             <span>${item.title}</span>
                         </a></td>`;
-                        html += '<td>' + item.createdDate + '</td>';
+                        html += '<td class="format-date">' + item.createdDate + '</td>';
                         html += '<td>관리자</td>';
                         html += '<td>' + item.hit + '</td>';
                         html += '</tr>'
                     });
                     $("#list").append(html);
+                    setTimeZoneAndFormat();
                 },
                 error: function (response) {
                     toastr.error('공지사항을 불러오는데 실패했습니다.');
@@ -217,12 +217,13 @@
 
                             <span>${item.title}</span>
                         </a></td>`;
-                        html += '<td>' + item.createdDate + '</td>';
+                        html += '<td class="format-date">' + item.createdDate + '</td>';
                         html += '<td>관리자</td>';
                         html += '<td>' + item.hit + '</td>';
                         html += '</tr>'
                     });
                     $("#list").append(html);
+                    setTimeZoneAndFormat();
                 },
                 error: function (response) {
                     toastr.error('뉴스를 불러오는데 실패했습니다.');

--- a/src/main/resources/templates/chat/room.html
+++ b/src/main/resources/templates/chat/room.html
@@ -97,7 +97,7 @@
             // 구독 설정
             stompClient.subscribe('/sub/chat/' + roomId, function (message) {
                 let messageBody = JSON.parse(message.body);
-                displayMessage(messageBody.nickname, messageBody.message, messageBody.timestamp, messageBody.senderId === senderId);
+                displayMessage(messageBody.nickname, messageBody.message, messageBody.timestamp, messageBody.senderId === senderId, messageBody.type);
             });
         });
 
@@ -137,7 +137,7 @@
                     currentPage++;
                     // 메시지를 역순으로 반복하여 추가
                     response.content.forEach(message => {
-                        displayMessage(message.nickname, message.message, message.timestamp, message.senderId === senderId);
+                        displayMessage(message.nickname, message.message, message.timestamp, message.senderId === senderId, message.type);
                     });
                     newMessage = true;
 
@@ -159,11 +159,11 @@
 
         document.getElementById('sendMessageButton').addEventListener('click', function () {
             let messageContent = document.getElementById('messageInput').value.trim();
-            // if (messageContent.trim() === '' || messageContent.length > 1000) {
-            //     toastr.error('메시지를 입력해주세요. (최대 1000자)');
-            //     $('#messageInput').focus();
-            //     return;
-            // }
+            if (messageContent.trim() === '' || messageContent.length > 1000) {
+                toastr.error('메시지를 입력해주세요. (최대 1000자)');
+                $('#messageInput').focus();
+                return;
+            }
             if (messageContent && stompClient) {
                 let chatMessage = {
                     roomId: roomId,
@@ -177,31 +177,57 @@
             }
         });
 
-        function displayMessage(nickname, message, timestamp, isMine) {
-            let messageBox = $('<div></div>').addClass('message-box');
-            let messageElement = $('<span></span>').addClass('message-content');
-            let nicknameElement = $('<span></span>').addClass('nickname').text(nickname);
-            let timestampElement = $('<span class="format-date"></span>').addClass('timestamp');
+        function displayMessage(nickname, message, timestamp, isMine, type) {
+            switch (type) {
+                case 'TALK':
+                    let messageBox = $('<div></div>').addClass('message-box');
+                    let messageElement = $('<span></span>').addClass('message-content');
+                    let nicknameElement = $('<span></span>').addClass('nickname').text(nickname);
+                    let timestampElement = $('<span class="format-date"></span>').addClass('timestamp');
 
-            messageElement.text(message);
-            nicknameElement.text(nickname);
-            timestampElement.text(timestamp);
+                    messageElement.text(message);
+                    nicknameElement.text(nickname);
+                    timestampElement.text(timestamp);
 
-            if (isMine) {
-                messageBox.addClass('my-message-box');
-                messageElement.addClass('my-message');
-            } else {
-                messageBox.addClass('other-message-box');
-                messageElement.addClass('other-message');
-            }
+                    if (isMine) {
+                        messageBox.addClass('my-message-box');
+                        messageElement.addClass('my-message');
+                    } else {
+                        messageBox.addClass('other-message-box');
+                        messageElement.addClass('other-message');
+                    }
 
-            messageBox.append(nicknameElement);
-            messageBox.append(messageElement);
-            messageBox.append(timestampElement);
-            if (newMessage) {
-                $('#chatMessages').append(messageBox);
-            } else {
-                $('#chatMessages').prepend(messageBox);
+                    messageBox.append(nicknameElement);
+                    messageBox.append(messageElement);
+                    messageBox.append(timestampElement);
+                    if (newMessage) {
+                        $('#chatMessages').append(messageBox);
+                    } else {
+                        $('#chatMessages').prepend(messageBox);
+                    }
+                    break;
+                case 'ENTER':
+                    let enterMessage = $('<div></div>').addClass('enter-message').text(nickname + message);
+                    let enterTime = $('<div class="format-date"></div>').text(timestamp).addClass('timestamp-enter');
+                    if(newMessage){
+                        $('#chatMessages').append(enterMessage);
+                        $('#chatMessages').append(enterTime);
+                    }else {
+                        $('#chatMessages').prepend(enterTime);
+                        $('#chatMessages').prepend(enterMessage);
+                    }
+                    break;
+                case 'QUIT':
+                    let quitMessage = $('<div></div>').addClass('quit-message').text(nickname + message);
+                    let quitTime = $('<div class="format-date"></div>').text(timestamp).addClass('timestamp-quit');
+                    if(newMessage){
+                        $('#chatMessages').append(quitMessage);
+                        $('#chatMessages').append(quitTime);
+                    }else {
+                        $('#chatMessages').prepend(quitTime);
+                        $('#chatMessages').prepend(quitMessage);
+                    }
+                    break;
             }
             setTimeZoneAndFormat();
 

--- a/src/main/resources/templates/fragment/footer.html
+++ b/src/main/resources/templates/fragment/footer.html
@@ -33,7 +33,7 @@
                     </form>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-dismiss="modal">취소</button>
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
                     <button type="button" class="btn btn-primary" id="btn-send-message">보내기</button>
                 </div>
             </div>

--- a/src/main/resources/templates/fragment/header.html
+++ b/src/main/resources/templates/fragment/header.html
@@ -171,6 +171,7 @@
                 type: "GET",
                 success: function (response) {
                     $("#message-body").empty(); // 기존 내용 제거
+                    $("#message-detail").empty(); // 기존 내용 제거
                     let modalBody = $("#messageModal #message-body");
                     modalBody.empty(); // 기존 내용 제거
 

--- a/src/main/resources/templates/view/view.html
+++ b/src/main/resources/templates/view/view.html
@@ -191,7 +191,6 @@
                             ht += `</span>
                            <div class='context-menu'>
                                 <a href='#' class='send-message-link' data-member-id='${val.member}' data-member-name='${val.nickName}'>쪽지 보내기</a>
-                                <a href='/member/user/${val.member}'>유저 정보 보기</a>
                             </div>`;
                             ht += `</div><div style="width:120px " class="format-date">${val.createdDate}</div>
                                                 </div>
@@ -284,7 +283,6 @@
                                         ht += `</span>
                            <div class='context-menu'>
                                 <a href='#' class='send-message-link' data-member-id='${value.memberId}' data-member-name='${value.nickName}'>쪽지 보내기</a>
-                                <a href='/member/user/${value.memberId}'>유저 정보 보기</a>
                             </div></div>`;
                                         ht += `<div style="margin-left: auto"><span class="format-date">${value.createDate}</span>`;
                                         if (value.checkUser == true) {

--- a/src/test/java/chathealth/chathealth/repository/post/PostRepositoryImplTest.java
+++ b/src/test/java/chathealth/chathealth/repository/post/PostRepositoryImplTest.java
@@ -83,7 +83,6 @@ class PostRepositoryImplTest {
         //when
         List<Post> posts = postRepository.getPosts(postSearch);
         //then
-//        System.out.println("posts = " + posts);
     }
 
     @Test

--- a/src/test/java/chathealth/chathealth/service/PostServiceTest.java
+++ b/src/test/java/chathealth/chathealth/service/PostServiceTest.java
@@ -154,9 +154,6 @@ class PostServiceTest {
 
         //when
         List<PostResponse> posts = postService.getPosts(postSearch);
-        for (PostResponse postResponse : posts) {
-            System.out.println("postResponsezzz = " + postResponse);
-        }
 
         //then
         assertThat(posts.size()).isEqualTo(20);
@@ -273,7 +270,6 @@ class PostServiceTest {
         //when
         List<MaterialSymptomDto> materialBySymptomType = postService.getMaterialBySymptomType();
         //then
-        System.out.println("materialBySymptomType = " + materialBySymptomType);
         assertThat(materialBySymptomType.size()).isEqualTo(10);
     }
 }


### PR DESCRIPTION
### 수정 사항
- 입장과 퇴장 메세지가 `content`가 없어 `validator` 오류에 걸려 그것을 처리하고 내보냄
- 색깔로도 구분, 개인 메세지가 아닌 시스템 메세지처럼 나타나게 함
- 확인 안한 쪽지 선택 시 `message-detail` 비움
- 메세지 보내기 닫기(취소) 버튼 누르면 모달 닫힘
- 채팅방 목록에서 전체 채팅방은 정상적으로 참여 멤버 수 나오는데 참여중인 채팅방은 한 명(나 자신) 밖에 나오지 않아서 서브 쿼리를 활용하여 수정하였음