### PR TITLE
fix: getPosts메서드에서 softDelete된 리뷰 제외

### DIFF
--- a/src/main/java/chathealth/chathealth/entity/post/Post.java
+++ b/src/main/java/chathealth/chathealth/entity/post/Post.java
@@ -79,11 +79,6 @@ public class Post extends BaseEntity {
         return postLikeList.size();
     }
 
-    public Integer getReviewCount() {
-        if(reviewList == null) return 0;
-        return reviewList.size();
-    }
-
     public void update(PostWriteDto postWriteDto,Symptom symptom) {
         this.content = postWriteDto.getContent();
         this.title = postWriteDto.getTitle();

--- a/src/main/java/chathealth/chathealth/service/PostService.java
+++ b/src/main/java/chathealth/chathealth/service/PostService.java
@@ -453,6 +453,9 @@ public class PostService {
                                 .map(PicturePost::getPictureUrl)
                                 .orElse(null);
                     }
+                    int reviews = post.getReviewList().stream()
+                            .filter(review -> review.getDeletedDate() == null)
+                            .toList().size();
 
                     return PostResponse.builder()
                             .id(post.getId())
@@ -463,7 +466,7 @@ public class PostService {
                             .createdAt(post.getCreatedDate())
                             .hitCount(post.getPostHitCount())
                             .likeCount(post.getPostLikeCount())
-                            .reviewCount(post.getReviewCount())
+                            .reviewCount(reviews)
                             .build();
                 })
                 .toList();


### PR DESCRIPTION
getPosts 메서드에서 reviewCount로 전체를 불러오다 보니 deletedDate가 null이 아닌 것까지 개수를 포함해서 조회하는 문제가 발생하여서 메모리 상에서 deletedDate가 null인 것만 조회하도록 stream의 filter를 사용했습니다