### PR TITLE
refactor: 최근 조회 항목 cookie로 조회

### DIFF
--- a/src/main/java/chathealth/chathealth/config/SecurityConfig.java
+++ b/src/main/java/chathealth/chathealth/config/SecurityConfig.java
@@ -9,7 +9,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -36,7 +35,7 @@ public class SecurityConfig {
                                  "/board-image/print","/post-img/**","/profile/**"
                                     ,"/view/**", "/review/**","/comment/**",
                                 "/auth/login-check", "/auth/is-user", "/auth/is-ent",
-                                "/noty/subscribe")
+                                "/noty/subscribe", "/api/post/recent-view")
                         .permitAll()
                         .requestMatchers("/admin/**").hasRole("ADMIN") // admin role 가지고 있는 사람만 허용
                         .anyRequest()

--- a/src/main/java/chathealth/chathealth/controller/PostRestController.java
+++ b/src/main/java/chathealth/chathealth/controller/PostRestController.java
@@ -1,39 +1,42 @@
 package chathealth.chathealth.controller;
 
 import chathealth.chathealth.dto.request.PostSearch;
-import chathealth.chathealth.dto.response.member.CustomUserDetails;
 import chathealth.chathealth.dto.response.PostResponse;
+import chathealth.chathealth.dto.response.RecentViewPost;
 import chathealth.chathealth.service.PostService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/post")
 public class PostRestController {
 
     private final PostService postService;
 
-    @GetMapping("/api/post")
+    @GetMapping
     public List<PostResponse> getPosts(PostSearch postSearch) {
         return postService.getPosts(postSearch);
     }
 
-    @GetMapping("/api/post/best")
+    @GetMapping("/best")
     public List<PostResponse> getBestPostsPerDay() {
         return postService.getBestPostsPerDay();
     }
 
-    @GetMapping("/api/post/best-week")
+    @GetMapping("/best-week")
     public List<PostResponse> getBestPostsPerWeek() {
         return postService.getBestPostsPerWeek();
     }
 
-    @GetMapping("/api/post/recent")
-    public List<PostResponse> getRecentPosts(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        return postService.getRecentPosts(customUserDetails.getLoggedMember());
+    @GetMapping("/recent-view")
+    public List<RecentViewPost> getRecentViewPosts(HttpServletRequest request) {
+
+        return postService.getRecentViewPosts(request);
     }
 }

--- a/src/main/java/chathealth/chathealth/controller/view/ViewController.java
+++ b/src/main/java/chathealth/chathealth/controller/view/ViewController.java
@@ -5,6 +5,8 @@ import chathealth.chathealth.dto.request.PostHitCountDto;
 import chathealth.chathealth.dto.response.member.CustomUserDetails;
 import chathealth.chathealth.dto.response.PostResponseDetails;
 import chathealth.chathealth.service.PostService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -22,7 +24,11 @@ public class ViewController {
 
     private final PostService postService;
     @GetMapping("/{id}")
-    public String viewPage(@PathVariable long id, Model model, @AuthenticationPrincipal CustomUserDetails userid){
+    public String viewPage(@PathVariable long id, Model model, @AuthenticationPrincipal CustomUserDetails userid,
+                           HttpServletRequest request, HttpServletResponse response){
+
+        //최근 본 게시물
+        postService.postRecentView(id,request,response);
         //post정보
         PostResponseDetails post=postService.getAllView(id);
         if(userid==null){

--- a/src/main/java/chathealth/chathealth/dto/response/RecentViewPost.java
+++ b/src/main/java/chathealth/chathealth/dto/response/RecentViewPost.java
@@ -1,0 +1,21 @@
+package chathealth.chathealth.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class RecentViewPost {
+
+    private Long id;
+
+    private String title;
+
+    private String representativeImg;
+
+    @Builder
+    public RecentViewPost(Long id, String title, String representativeImg) {
+        this.id = id;
+        this.title = title;
+        this.representativeImg = representativeImg;
+    }
+}

--- a/src/main/java/chathealth/chathealth/entity/post/PostHit.java
+++ b/src/main/java/chathealth/chathealth/entity/post/PostHit.java
@@ -8,9 +8,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-import java.lang.management.MemoryManagerMXBean;
-import java.time.LocalDateTime;
-
 @Entity
 @Getter
 @Table(name = "PostHit")
@@ -30,7 +27,4 @@ public class PostHit extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    public void update(){
-        super.modifiedDate= LocalDateTime.now();
-    }
 }

--- a/src/main/java/chathealth/chathealth/repository/post/PostRepository.java
+++ b/src/main/java/chathealth/chathealth/repository/post/PostRepository.java
@@ -1,8 +1,8 @@
 package chathealth.chathealth.repository.post;
 
-import chathealth.chathealth.entity.post.MaterialPost;
 import chathealth.chathealth.entity.post.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
@@ -11,5 +11,9 @@ import java.util.List;
 public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
     List<Post> findByMemberId(Long id);
     List<Post> findByMaterialListMaterialIdIn(List<Long> materialIds);
+
+
+    @Query("select p from Post p left join fetch PicturePost pp on p = pp.post where p.id in :list")
+    List<Post> findAllByIdIn(List<Long> list);
 }
 

--- a/src/main/java/chathealth/chathealth/repository/post/PostRepositoryCustom.java
+++ b/src/main/java/chathealth/chathealth/repository/post/PostRepositoryCustom.java
@@ -1,7 +1,6 @@
 package chathealth.chathealth.repository.post;
 
 import chathealth.chathealth.dto.request.PostSearch;
-import chathealth.chathealth.entity.member.Member;
 import chathealth.chathealth.entity.post.Post;
 
 import java.util.List;
@@ -16,5 +15,4 @@ public interface PostRepositoryCustom {
 
     List<Post> getBestPostsPerWeek();
 
-    List<Post> getRecentPosts(Member member);
 }

--- a/src/main/java/chathealth/chathealth/repository/post/PostRepositoryImpl.java
+++ b/src/main/java/chathealth/chathealth/repository/post/PostRepositoryImpl.java
@@ -1,7 +1,6 @@
 package chathealth.chathealth.repository.post;
 
 import chathealth.chathealth.dto.request.PostSearch;
-import chathealth.chathealth.entity.member.Member;
 import chathealth.chathealth.entity.post.Post;
 import chathealth.chathealth.entity.post.SymptomType;
 import com.querydsl.core.types.OrderSpecifier;
@@ -83,17 +82,6 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 .leftJoin(postHit).on(postHit.post.eq(post))
                 .orderBy(postHit.count().desc())
                 .groupBy(post)
-                .limit(5)
-                .fetch();
-    }
-
-    @Override
-    public List<Post> getRecentPosts(Member member) {
-        return queryFactory.selectFrom(post)
-                .where(post.deletedDate.isNull(),
-                        postHit.member.eq(member))
-                .leftJoin(postHit).on(postHit.post.eq(post))
-                .orderBy(postHit.modifiedDate.desc())
                 .limit(5)
                 .fetch();
     }

--- a/src/main/resources/templates/fragment/header.html
+++ b/src/main/resources/templates/fragment/header.html
@@ -15,16 +15,14 @@
                     <span class="navbar-toggler-icon"></span>
                 </button>
                 <div class="collapse navbar-collapse" id="navbarNavDropdown">
-                    <th:block sec:authorize="!isAuthenticated()">
                         <ul class="navbar-nav ms-auto">
+                    <th:block sec:authorize="!isAuthenticated()">
                             <li class="nav-item"><a href="#" th:href="@{/post}" class="nav-link">건강기능식품</a></li>
                             <li class="nav-item"><a href="#" th:href="@{/board}" class="nav-link">커뮤니티</a></li>
                             <li class="nav-item"><a href="#" th:href="@{/auth/selection}" class="nav-link">회원가입</a></li>
                             <li class="nav-item"><a href="#" th:href="@{/auth/login}" class="nav-link">로그인</a></li>
-                        </ul>
                     </th:block>
                     <th:block sec:authorize="isAuthenticated()">
-                        <ul class="navbar-nav ms-auto">
                             <th:block sec:authorize="hasAnyRole('ROLE_USER','ROLE_ADMIN')">
                                 <li class="nav-item">
                                     <button id="messageButton" class="nav-link position-relative">
@@ -45,12 +43,26 @@
                             <li class="nav-item" sec:authorize="hasRole('ROLE_REJECTED_ENT')"><a href="" th:href="@{|/member/ent/${#authentication.principal.loggedMember.id}|}" class="nav-link">마이 페이지</a></li>
                             <li class="nav-item" sec:authorize="hasRole('ROLE_ADMIN')"><a href="" th:href="@{/member/admin}" class="nav-link">관리자페이지</a></li>
                             <li class="nav-item"><a href="" th:href="@{/auth/logout}" class="nav-link">로그아웃</a></li>
-                        </ul>
                     </th:block>
+                            <li class="nav-item"><a href="#" class="nav-link" data-bs-toggle="offcanvas" data-bs-target="#offcanvasRight" aria-controls="offcanvasRight"><i class="fas fa-sticky-note" style="color: #bfa95a;"></i></a></li>
+                        </ul>
 
                 </div>
             </div>
         </nav>
+
+
+        <div class="offcanvas offcanvas-end" tabindex="-1" id="offcanvasRight" aria-labelledby="offcanvasRightLabel">
+            <div class="offcanvas-header">
+                <h5 class="offcanvas-title" id="offcanvasRightLabel">최근 조회 상품</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+            </div>
+            <div class="offcanvas-body">
+                <ul id = "recent-posts" class="list-group">
+                    <!-- 여기에 최근 조회 상품을 동적으로 로드 -->
+                </ul>
+            </div>
+        </div>
 
         <!-- 쪽지함 모달 -->
         <div class="modal fade" id="messageModal" tabindex="-1" aria-labelledby="messageModalLabel" aria-hidden="true">
@@ -155,7 +167,44 @@
                     }
                 });
             }
+
+
+            $("#offcanvasRight").on('show.bs.offcanvas', function () {
+                getRecentPosts();
+            });
+
         });
+
+            function getRecentPosts(){
+                $.ajax({
+                    url: "/api/post/recent-view",
+                    type: "GET",
+                    success: function (response) {
+                        let recentPosts = $("#recent-posts");
+                        recentPosts.empty();
+                        let html = "";
+                        console.log(response);
+
+                        $.each(response, function (index, post) {
+                            html += `<li class="list-group-item">
+                                        <a target="_blank"  href="/view/${post.id}" style="text-decoration: none; color:inherit">`
+                            if(post.representativeImg != null){
+                                html +=  `<div><img src="${post.representativeImg}" alt="상품 이미지" style="width: 200px; height: 200px; object-fit: cover"></div>`
+                            }else {
+                                html += `<div><img src="/img/basic_post.svg" alt="상품 이미지" style="width: 200px; height: 200px; object-fit: cover"></div>`
+                            }
+                             html += `<div>${post.title}</div>
+                                        </a>
+                                    </li>`;
+                        })
+
+                        recentPosts.append(html);
+                    },
+                    error: function (response) {
+                        toastr.error(response.message);
+                    }
+                })
+            }
 
 
 

--- a/src/main/resources/templates/post/post.html
+++ b/src/main/resources/templates/post/post.html
@@ -97,13 +97,6 @@
 
                 </div>
             </div>
-            <div sec:authorize="isAuthenticated()" class="right-box" style="top:500px" id="view-recent">
-                <h4>최근 조회</h4>
-                <!--    로그인 했을 때만 나타남           게시물 리스트-->
-                <div>
-
-                </div>
-            </div>
         </div>
     </div>
 
@@ -148,35 +141,6 @@
                 }
             });
 
-            // 최근 조회 로그인 했을 때만 실행
-            const isAuth = [[${isAuth}]];
-            if(isAuth) {
-                $.ajax({
-                    url: "/api/post/recent",
-                    type: "GET",
-                    success: function (response) {
-                        let html = "";
-                        if (response.length === 0) {
-                            html += "<h2>아직 조회한 글이 없습니다.</h2>";
-                        }
-                        let i = 1;
-                        html += "<table class=\"table table-hover\">";
-                        $.each(response, function (index, item) {
-                            html += "<tr>";
-                            html += '<th>' + (index + 1) + '</th>'; // "
-                            html += '<td>' + "<a target=\"_blank\" rel=\"noopener noreferrer\" href='/view/" + item.id + "' style='text-decoration: none; color: inherit'>" + item.title + '</a></td>';
-                            html += "</tr>";
-                        });
-                        html += "</table>";
-                        $('#view-recent div').html(html);
-                    },
-                    error: function (error) {
-                        alert(JSON.stringify(error));
-                    },
-                    complete: function () {
-                    }
-                });
-            }
         });
 
         document.querySelectorAll('.btn-symptom').forEach(function (button) {


### PR DESCRIPTION
## 최근 조회 항목 조회하는 로직 수정

### 기존 로직 문제
- post에 조회할 때마다 select 후 modifyDate를 업데이트 하여 db 조회 및 업데이트가 잦음
- 로그인하지 않은 유저는 최근 조회 항목 조회 불가능

### 개선 방향
- 브라우저의 Cookie(recentView)를 이용하여 최근 조회한 5개의 포스트를 id를 고유값으로 받아 리스트로 반환
- 상품 조회시 기존의 recentView에 속해 있다면 없애고 첫 번째 인덱스로 삽입
- 5개가 넘어가면 가장 오래된 상품의 id를 삭제 후 첫 번째 인덱스로 삽입
- 우측 상단의 버튼을 눌렀을 때만 호출하여 필요할 때만 api를 호출하도록 함 (header에 버튼이 있어 어느 페이지에서든 접근 가능하도록 하였습니다.)