### PR TITLE
fix: post 페이지네이션 수정

### DIFF
--- a/src/main/java/chathealth/chathealth/constants/HitPeriod.java
+++ b/src/main/java/chathealth/chathealth/constants/HitPeriod.java
@@ -1,0 +1,5 @@
+package chathealth.chathealth.constants;
+
+public enum HitPeriod {
+    DAY, WEEK
+}

--- a/src/main/java/chathealth/chathealth/repository/post/PostRepositoryImpl.java
+++ b/src/main/java/chathealth/chathealth/repository/post/PostRepositoryImpl.java
@@ -55,7 +55,9 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 .where(post.deletedDate.isNull(),
                         titleContains(postSearch.getTitle()),
                         symptomTypeEq(postSearch.getSymptomType()),
-                        materialIn(postSearch.getMaterialName())
+                        materialIn(postSearch.getMaterialName()),
+                        companyContains(postSearch.getCompany())
+
                 )
                 .leftJoin(post.symptom, symptom)
                 .leftJoin(post.materialList)

--- a/src/main/java/chathealth/chathealth/service/PostService.java
+++ b/src/main/java/chathealth/chathealth/service/PostService.java
@@ -1,6 +1,7 @@
 package chathealth.chathealth.service;
 
 
+import chathealth.chathealth.constants.HitPeriod;
 import chathealth.chathealth.dto.request.*;
 import chathealth.chathealth.dto.response.*;
 import chathealth.chathealth.dto.response.member.CustomUserDetails;
@@ -472,13 +473,13 @@ public class PostService {
 
     public List<PostResponse> getBestPostsPerDay() {
         return postRepository.getBestPostsPerDay().stream()
-                .map(this::createRecentPostResponse)
+                .map(post -> createRecentPostResponse(post, HitPeriod.DAY))
                 .toList();
     }
 
     public List<PostResponse> getBestPostsPerWeek() {
         return postRepository.getBestPostsPerWeek().stream()
-                .map(this::createRecentPostResponse)
+                .map(post -> createRecentPostResponse(post, HitPeriod.WEEK))
                 .toList();
     }
 
@@ -554,7 +555,7 @@ public class PostService {
 
     }
 
-    private PostResponse createRecentPostResponse(Post post) {
+    private PostResponse createRecentPostResponse(Post post, HitPeriod period) {
         String representativeImg = null;
         if (post.getPostImgList() != null && !post.getPostImgList().isEmpty()) {
             representativeImg = post.getPostImgList().stream()
@@ -563,10 +564,18 @@ public class PostService {
                     .map(PicturePost::getPictureUrl)
                     .orElse(null);
         }
+
+        int size = 0;
+
+        if(period == HitPeriod.DAY){
+            size = post.getPostHitList().stream().filter(postHit -> postHit.getCreatedDate().isAfter(LocalDateTime.now().minusDays(1))).toList().size();
+        }else if(period == HitPeriod.WEEK){
+            size = post.getPostHitList().stream().filter(postHit -> postHit.getCreatedDate().isAfter(LocalDateTime.now().minusWeeks(1))).toList().size();
+        }
         return PostResponse.builder()
                 .id(post.getId())
                 .title(post.getTitle())
-                .hitCount(post.getPostHitCount())
+                .hitCount(size)
                 .representativeImg(representativeImg)
                 .build();
     }

--- a/src/main/resources/templates/post/post.html
+++ b/src/main/resources/templates/post/post.html
@@ -204,7 +204,7 @@
                         html += "<h2>검색 결과가 없습니다.</h2>";
                     } else {
                         html += "<h2>검색 결과 : " + response[0].count + "건</h2>";
-                        totalPage = Math.floor(response[0].count / size + 1);
+                        totalPage = Math.ceil(response[0].count / size);
                     }
                     $.each(response, function (index, item) {
                         if (item.representativeImg === null) {


### PR DESCRIPTION
## fix
### pagination (post)
- 20페이지일 때 2페이지가 보임 수정 Math.floor -> Math.ceil로 수정
- 상호명 검색시 count 안바뀜 -> 카운트 쿼리 수정

## refactor
### 일간, 주간, 전체 조회수 구분
- 일간 최다 조회, 주간 최다 조회에서 전체 조회수로 나오는 조회수 갯수로 인해 헷갈린다는 의견이 있어서 구분했습니다.
- filter를 사용해 해당하는 조회수만 구하도록 구성하였습니다.